### PR TITLE
Git diff-tree vs ls-tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 <!-- @doxie.inject start toc -->
 <!-- Don’t remove or change the comment above – that can break automatic updates. -->
 * [Overwrite pull](https://github.com/git-tips/tips#overwrite-pull)
-* [List of all the files changed in a commit](https://github.com/git-tips/tips#list-of-all-the-files-changed-in-a-commit)
+* [List of all files changed in a commit](https://github.com/git-tips/tips#list-of-all-files-changed-in-a-commit)
+* [List of all files till a commit](https://github.com/git-tips/tips#list-of-all-files-till-a-commit)
 * [Git reset first commit](https://github.com/git-tips/tips#git-reset-first-commit)
 * [List all the conflicted files](https://github.com/git-tips/tips#list-all-the-conflicted-files)
 * [List all branches that are already merged into master](https://github.com/git-tips/tips#list-all-branches-that-are-already-merged-into-master)
@@ -35,7 +36,12 @@
 git fetch --all && git reset --hard origin/master
 ```
 
-## List of all the files changed in a commit
+## List of all files changed in a commit
+```sh
+git diff-tree --no-commit-id --name-only -r <commit-ish>
+```
+
+## List of all files till a commit
 ```sh
 git ls-tree --name-only -r <commit-ish>
 ```

--- a/tips.json
+++ b/tips.json
@@ -4,7 +4,11 @@
       "tip": "git fetch --all && git reset --hard origin/master"
   },
   {
-      "title": "List of all the files changed in a commit",
+      "title": "List of all files changed in a commit",
+      "tip": "git diff-tree --no-commit-id --name-only -r <commit-ish>"
+  },
+  {
+      "title": "List of all files till a commit",
       "tip": "git ls-tree --name-only -r <commit-ish>"
   },
   {


### PR DESCRIPTION
## Git diff-tree vs ls-tree

- `ls-tree` - List of all files till a commit
- `diff-tree` - List of all files changed in a commit
- We are using `--no-commit-id` in `diff-tree` to hide commit hash id

![Screenshoot](http://f.cl.ly/items/3A3B30070o122F2f0L1Y/Screen%20Shot%202015-07-25%20at%209.56.17%20pm.png)