### PR TITLE
Add an easier-to-read way to delete a remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,12 @@ git branch -d <local_branchname>
 
 ## Delete remote branch
 ```sh
+git push origin --delete <remote_branchname>
+```
+
+
+__Alternatives:__
+```sh
 git push origin :<remote_branchname>
 ```
 

--- a/tips.json
+++ b/tips.json
@@ -45,7 +45,8 @@
   },
   {
       "title": "Delete remote branch",
-      "tip": "git push origin :<remote_branchname>"
+      "tip": "git push origin --delete <remote_branchname>",
+      "alternatives": ["git push origin :<remote_branchname>"]
   },
   {
       "title": "Undo local changes with the last content in head",


### PR DESCRIPTION
Since 2010 Git supports the `--delete` argument for git-push as an
alias for the `:branch` syntax, i.e. these commands are equivalent:

    $ git push origin :foo
    $ git push origin --delete foo

This patch changes the tip to use the `--delete` argument on the
grounds that it is easier to remember, easier to understand, and
easily available since it is unlikely for people to be using a version
of Git which is more than five years old.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>