### PR TITLE
Add a tip to show the most recent tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@
 * [Ignore one file on commit (e.g. Changelog).](https://github.com/git-tips/tips#ignore-one-file-on-commit-eg-changelog)
 * [Stash changes before rebasing](https://github.com/git-tips/tips#stash-changes-before-rebasing)
 * [Fetch pull request by ID to a local branch](https://github.com/git-tips/tips#fetch-pull-request-by-id-to-a-local-branch)
+* [Show the most recent tag on the current branch](https://github.com/git-tips/tips#show-the-most-recent-tag-on-the-current-branch)
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
 <!-- @doxie.inject end toc -->
@@ -465,6 +466,11 @@ git fetch origin pull/<id>/head:<branch-name>
 __Alternatives:__
 ```sh
 git pull origin pull/<id>/head:<branch-name>
+```
+
+## Show the most recent tag on the current branch
+```sh
+git describe --tags --abbrev=0
 ```
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->

--- a/tips.json
+++ b/tips.json
@@ -264,5 +264,9 @@
     "title": "Fetch pull request by ID to a local branch",
     "tip": "git fetch origin pull/<id>/head:<branch-name>",
     "alternatives": ["git pull origin pull/<id>/head:<branch-name>"]
+  },
+  {
+    "title": "Show the most recent tag on the current branch",
+    "tip": "git describe --tags --abbrev=0"
   }
 ]


### PR DESCRIPTION
This tip shows how to display the most recent tag reachable on the
current branch.  The use of `--abbrev=0` is necessary otherwise the
output would contain additional information (specifically part of a
commit hash), appended to the tag name.  It's worth noting that this
command is usable for branches other than the current one, e.g.

    $ git describe --tags --abbrev=0 master

That would show the most recent tag on the `master` branch regardless
of whatever branch the user is currently on.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>