### PR TITLE
Show how to read guides that come with Git

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 <!-- @doxie.inject start toc -->
 <!-- Don’t remove or change the comment above – that can break automatic updates. -->
 * [Everyday Git in twenty commands or so](https://github.com/git-tips/tips#everyday-git-in-twenty-commands-or-so)
+* [Show helpful guides that come with Git](https://github.com/git-tips/tips#show-helpful-guides-that-come-with-git)
 * [Overwrite pull](https://github.com/git-tips/tips#overwrite-pull)
 * [List of all files till a commit](https://github.com/git-tips/tips#list-of-all-files-till-a-commit)
 * [Git reset first commit](https://github.com/git-tips/tips#git-reset-first-commit)
@@ -77,6 +78,11 @@
 ## Everyday Git in twenty commands or so
 ```sh
 git help everyday
+```
+
+## Show helpful guides that come with Git
+```sh
+git help -g
 ```
 
 ## Overwrite pull

--- a/tips.json
+++ b/tips.json
@@ -4,6 +4,10 @@
       "tip": "git help everyday"
   },
   {
+      "title": "Show helpful guides that come with Git",
+      "tip": "git help -g"
+  },
+  {
       "title": "Overwrite pull",
       "tip": "git fetch --all && git reset --hard origin/master"
   },


### PR DESCRIPTION
This patch adds a tip explaining `git help -g`.  That command will
list a collection of useful guides that come "pre-built" with Git,
e.g. `git help workflows` and `git help revisions`.  These are useful
resources for learning and looking-up common Git concepts and
techniques, and that broad usefulness is the justification for placing
the tip near the very top of the list.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>