### PR TITLE
Added tip to remove an entry from the global config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@
 * [Prune all unreachable objects from the object database.](https://github.com/git-tips/tips#prune-all-unreachable-objects-from-the-object-database)
 * [Instantly browse your working repository in gitweb.](https://github.com/git-tips/tips#instantly-browse-your-working-repository-in-gitweb)
 * [View the GPG signatures in the commit log](https://github.com/git-tips/tips#view-the-gpg-signatures-in-the-commit-log)
+* [Remove entry in the global config.](https://github.com/git-tips/tips#remove-entry-in-the-global-config)
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
 <!-- @doxie.inject end toc -->
@@ -657,6 +658,11 @@ git instaweb [--local] [--httpd=<httpd>] [--port=<port>] [--browser=<browser>]
 ## View the GPG signatures in the commit log
 ```sh
 git log --show-signature
+```
+
+## Remove entry in the global config.
+```sh
+git config --global --unset <entry-name>
 ```
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->

--- a/tips.json
+++ b/tips.json
@@ -293,4 +293,7 @@
 },{
    "title": "View the GPG signatures in the commit log",
    "tip": "git log --show-signature"
+}, {
+    "title": "Remove entry in the global config.",
+    "tip": "git config --global --unset <entry-name>"
 }]


### PR DESCRIPTION
This tip allow you to remove an entry from the global config. I sometimes have set global configs with typos, or when I removing an undesired config entry. For instance

`git config --global help.autocorrect 15`

To remove it just run:

`git config --global --unset help.autocorrect`