### PR TITLE
Bypass pre-commit and commit-msg githooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [Merge previous two commits into one.](#merge-previous-two-commits-into-one)
 * [List all branch is WIP](#list-all-branch-is-wip)
 * [Find guilty with binary search](#find-guilty-with-binary-search)
+* [Bypass pre-commit and commit-msg githooks](#bypass-pre-commit-and-commit-msg-githooks)
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
 <!-- @doxie.inject end toc -->
@@ -713,6 +714,11 @@ git bisect good v2.6.13-rc2		# Set point to good commit|tag
 git bisect bad					# Say current state is bad
 git bisect good					# Say current state is good
 git bisect reset				# Finish search
+```
+
+## Bypass pre-commit and commit-msg githooks
+```sh
+git commit --no-verify
 ```
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->

--- a/tips.json
+++ b/tips.json
@@ -317,4 +317,8 @@
 }, {
   "title": "Find guilty with binary search",
   "tip": "git bisect start				# Search start \ngit bisect bad					# Set point to bad commit \ngit bisect good v2.6.13-rc2		# Set point to good commit|tag \ngit bisect bad					# Say current state is bad \ngit bisect good					# Say current state is good \ngit bisect reset				# Finish search \n"
-}]
+},
+  {
+    "title": "Bypass pre-commit and commit-msg githooks",
+    "tip": "git commit --no-verify"
+  }]


### PR DESCRIPTION
This tip allows you to commit without any _githook-checks_.