### PR TITLE
Use log instead of whatchanged

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,12 @@ curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completio
 
 ## What changed since two weeks?
 ```sh
+git log --no-merges --raw --since='2 weeks ago'
+```
+
+
+__Alternatives:__
+```sh
 git whatchanged --since='2 weeks ago'
 ```
 

--- a/tips.json
+++ b/tips.json
@@ -89,7 +89,8 @@
     "tip": "curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc"
 }, {
     "title": "What changed since two weeks?",
-    "tip": "git whatchanged --since='2 weeks ago'"
+    "tip": "git log --no-merges --raw --since='2 weeks ago'",
+    "alternatives": ["git whatchanged --since='2 weeks ago'"]
 }, {
     "title": "See all commits made since forking from master",
     "tip": "git log --no-merges --stat --reverse master.."


### PR DESCRIPTION
As per documentation (https://git-scm.com/docs/git-whatchanged):

"New users are encouraged to use git-log(1) instead. The whatchanged command is essentially the same as git-log(1) but defaults to show the raw format diff output and to skip merges.

The command is kept primarily for historical reasons; fingers of many people who learned Git long before git log was invented by reading Linux kernel mailing list are trained to type it."