### PR TITLE
Remove --no-run-if-empty flag on removing branches that are merged to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,7 +177,7 @@ git checkout -
 
 ## Remove branches that have already been merged with master
 ```sh
-git branch --merged master | grep -v '^\*' | xargs --no-run-if-empty -n 1 git branch -d
+git branch --merged master | grep -v '^\*' | xargs -n 1 git branch -d
 ```
 
 ## List all branches and their upstreams, as well as last commit on branch

--- a/tips.json
+++ b/tips.json
@@ -36,7 +36,7 @@
     "tip": "git checkout -"
 }, {
     "title": "Remove branches that have already been merged with master",
-    "tip": "git branch --merged master | grep -v '^\\*' | xargs --no-run-if-empty -n 1 git branch -d"
+    "tip": "git branch --merged master | grep -v '^\\*' | xargs -n 1 git branch -d"
 }, {
     "title": "List all branches and their upstreams, as well as last commit on branch",
     "tip": "git branch -vv"


### PR DESCRIPTION
On the tip: **Remove branches that have already been merged with master**
I tried to run the command as it is and got an error
```
xargs: illegal option -- -
```
Running just `git branch --merged master | grep -v '^\*' | xargs -n 1 git branch -d ` worked as it should and running the same command twice (when there are no applicable branches) threw no errors.