### PR TITLE
Ignore file mode changes on commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [Bypass pre-commit and commit-msg githooks](#bypass-pre-commit-and-commit-msg-githooks)
 * [List commits and changes to a specific file (even through renaming)](#list-commits-and-changes-to-a-specific-file-even-through-renaming)
 * [Clone a single branch](#clone-a-single-branch)
+* [Ignore file mode changes on commits](#ignore-file-mode-changes-on-commits)
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
 <!-- @doxie.inject end toc -->
@@ -737,6 +738,11 @@ git log --follow -p -- <file_path>
 ## Clone a single branch
 ```sh
 git clone -b <branch-name> --single-branch https://github.com/user/repo.git
+```
+
+## Ignore file mode changes on commits
+```sh
+git config core.fileMode false
 ```
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->

--- a/tips.json
+++ b/tips.json
@@ -327,4 +327,7 @@
 },{
     "title": "Clone a single branch",
     "tip": "git clone -b <branch-name> --single-branch https://github.com/user/repo.git"
+},{
+    "title": "Ignore file mode changes on commits",
+    "tip": "git config core.fileMode false"
 }]


### PR DESCRIPTION
Commit only adds a new tip: ignore file mode changes on commits. Sometimes git status shows a lot of modified files, but git diff shows that only the file mode changed.