### PR TITLE
Add alternatives to get commit hash of initial revision

### DIFF
--- a/README.md
+++ b/README.md
@@ -545,6 +545,12 @@ git remote prune origin
  git rev-list --reverse HEAD | head -1
 ```
 
+
+__Alternatives:__
+```sh
+git rev-list --max-parents=0 HEAD
+```
+
 ## Visualize the version tree.
 ```sh
 git log --pretty=oneline --graph --decorate --all

--- a/README.md
+++ b/README.md
@@ -551,6 +551,16 @@ __Alternatives:__
 git rev-list --max-parents=0 HEAD
 ```
 
+
+```sh
+git log --pretty=oneline | tail -1 | cut -c 1-40
+```
+
+
+```sh
+git log --pretty=oneline --reverse | head -1 | cut -c 1-40
+```
+
 ## Visualize the version tree.
 ```sh
 git log --pretty=oneline --graph --decorate --all

--- a/tips.json
+++ b/tips.json
@@ -198,7 +198,7 @@
 }, {
     "title": "Retrieve the commit hash of the initial revision.",
     "tip": " git rev-list --reverse HEAD | head -1",
-    "alternatives": ["git rev-list --max-parents=0 HEAD"]
+    "alternatives": ["git rev-list --max-parents=0 HEAD", "git log --pretty=oneline | tail -1 | cut -c 1-40", "git log --pretty=oneline --reverse | head -1 | cut -c 1-40"]
 }, {
     "title": "Visualize the version tree.",
     "tip": "git log --pretty=oneline --graph --decorate --all",

--- a/tips.json
+++ b/tips.json
@@ -197,7 +197,8 @@
     "alternatives": ["git remote prune origin"]
 }, {
     "title": "Retrieve the commit hash of the initial revision.",
-    "tip": " git rev-list --reverse HEAD | head -1"
+    "tip": " git rev-list --reverse HEAD | head -1",
+    "alternatives": ["git rev-list --max-parents=0 HEAD"]
 }, {
     "title": "Visualize the version tree.",
     "tip": "git log --pretty=oneline --graph --decorate --all",


### PR DESCRIPTION
Also, Should I add these also as `alternatives`??
These would give first `commit hash` along with `commit message`
`git log --pretty=oneline --reverse | head -1` and `git log --pretty=oneline | tail -1`

Since `commit hash` length is fixed, `cut` can be used to get only `commit hash`
like this -> `git log --pretty=oneline | tail -1 | cut -c 1-40`
But this needs use of different commands.
