### PR TITLE
simplify rebase command

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,7 +521,7 @@ git branch -m [<old-branch-name>] <new-branch-name>
 
 ## Rebases 'feature' to 'master' and merges it in to master 
 ```sh
-git checkout feature && git rebase @{-1} && git checkout @{-2} && git merge @{-1}
+git rebase master feature && git checkout master && git merge -
 ```
 
 ## Archive the `master` branch


### PR DESCRIPTION
Previous command *assumed* that the starting branch was master (bad! don't assume!)

Also, `git rebase foo bar` is shorthand for `git checkout bar && git rebase bar`