### PR TITLE
Add alternative for rebase on pulls (git < 1.7.9)

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,13 @@ git checkout <commit-ish> -- <file_path>
 git config --global pull.rebase true
 ```
 
+
+__Alternatives:__
+```sh
+#git < 1.7.9
+git config --global branch.autosetuprebase always
+```
+
 ## List all the alias and configs.
 ```sh
 git config --list

--- a/tips.json
+++ b/tips.json
@@ -258,7 +258,8 @@
     "tip": "git checkout <commit-ish> -- <file_path>"
 }, {
     "title": "Always rebase instead of merge on pull.",
-    "tip": "git config --global pull.rebase true"
+    "tip": "git config --global pull.rebase true",
+    "alternatives" : ["#git < 1.7.9\ngit config --global branch.autosetuprebase always"]
 }, {
     "title": "List all the alias and configs.",
     "tip": "git config --list"


### PR DESCRIPTION
Git v1.7.9+ re-commands this command instead -

```
git config --global branch.autosetuprebase always
```
https://coderwall.com/p/tnoiug/rebase-by-default-when-doing-git-pull

Thanks