### PR TITLE
Fixing git bash completion script URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ git add -p
 
 ## Get git bash completion
 ```sh
-curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc
+curl -L http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc
 ```
 
 ## What changed since two weeks?


### PR DESCRIPTION
http://git.io/vfhol
This URL leads to the needful script via redirect. When I do `$ curl http://git.io/vfhol` (on OSX, at least), it fetches redirect info:

```sh
<html><body>You are being <a href="https://git.io/vfhol">redirected</a>.</body></html>
```
When I set url to the updated one, everything works properly.