### PR TITLE
Add git status short

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [List references in a remote repository](#list-references-in-a-remote-repository)
 * [Backup untracked files.](#backup-untracked-files)
 * [List all git aliases](#list-all-git-aliases)
+* [Show git status short](#show-git-status-short)
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
 <!-- @doxie.inject end toc -->
@@ -1097,6 +1098,11 @@ git config -l | grep alias | sed 's/^alias\.//g'
 __Alternatives:__
 ```sh
 git config -l | grep alias | cut -d '.' -f 2
+```
+
+## Show git status short
+```sh
+git status --short --branch
 ```
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->

--- a/tips.json
+++ b/tips.json
@@ -470,4 +470,8 @@
     "title": "List all git aliases",
     "tip": "git config -l | grep alias | sed 's/^alias\\.//g'",
     "alternatives": ["git config -l | grep alias | cut -d '.' -f 2"]
-}]
+},{
+    "title": "Show git status short",
+    "tip": "git status --short --branch"
+}
+]


### PR DESCRIPTION
Shows git status in a shorter former. Generally known as 'pro status'.

I find that once you are used to git you have no need for all the description that the normal git status tells you. The short format becomes easier and quicker to read.