### PR TITLE
Fetch origin, not --all

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ git help -g
 
 ## Overwrite pull
 ```sh
-git fetch --all && git reset --hard origin/master
+git fetch origin && git reset --hard origin/master
 ```
 
 ## List of all files till a commit

--- a/tips.json
+++ b/tips.json
@@ -6,7 +6,7 @@
     "tip": "git help -g"
 }, {
     "title": "Overwrite pull",
-    "tip": "git fetch --all && git reset --hard origin/master"
+    "tip": "git fetch origin && git reset --hard origin/master"
 }, {
     "title": "List of all files till a commit",
     "tip": "git ls-tree --name-only -r <commit-ish>"


### PR DESCRIPTION
No need to fetch --all. Fetching origin is enough when we are resetting to origin/master.