### PR TITLE
Add alternative to remove remote tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,7 +285,13 @@ git tag -d <tag-name>
 
 ## Delete remote tag
 ```sh
-git push origin :refs/tags/<tag-name>
+git push origin :<remote_tagname>
+```
+
+
+__Alternatives:__
+```sh
+git push origin :refs/tags/<remote_tagname>
 ```
 
 ## Undo local changes with the last content in head


### PR DESCRIPTION
I changed the name `<tag-name>` to `<remote-tagname>` be more explicit and to be consistent with the same command but for branches a couple of lines up.