### PR TITLE
Bash completion: change short redirected url for full url

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ git add -p
 
 ## Get git bash completion
 ```sh
-curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc
+curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc
 ```
 
 ## What changed since two weeks?

--- a/tips.json
+++ b/tips.json
@@ -101,7 +101,7 @@
     "tip": "git add -p"
 }, {
     "title": "Get git bash completion",
-    "tip": "curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc"
+    "tip": "curl https://raw.githubusercontent.com/git/git/master/contrib/completion/git-completion.bash > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc"
 }, {
     "title": "What changed since two weeks?",
     "tip": "git log --no-merges --raw --since='2 weeks ago'",


### PR DESCRIPTION
http://git.io/vfhol returns a redirect. That could be solved with `curl -L`. However, for something that goes into the bash profile, I think that it is a good thing to download it with a descriptive https url