### PR TITLE
Fix difftool example

### DIFF
--- a/README.md
+++ b/README.md
@@ -728,7 +728,7 @@ git diff --word-diff
 
 ## Show changes using common diff tools.
 ```sh
-git difftool -t <commit1> <commit2> <path>
+git difftool [-t <tool>] <commit1> <commit2> <path>
 ```
 
 ## Don’t consider changes for tracked file.

--- a/tips.json
+++ b/tips.json
@@ -257,7 +257,7 @@
     "tip": "git diff --word-diff"
 }, {
     "title": "Show changes using common diff tools.",
-    "tip": "git difftool -t <commit1> <commit2> <path>"
+    "tip": "git difftool [-t <tool>] <commit1> <commit2> <path>"
 }, {
     "title": "Don’t consider changes for tracked file.",
     "tip": "git update-index --assume-unchanged <file_name>"


### PR DESCRIPTION
The example currently reads:

    git difftool -t <commit1> <commit2> <path>

This would cause `commit1` to be considered as the diff tool.