### PR TITLE
Add -L flag to follow redirect to get correct file

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,7 +372,7 @@ git add -p
 
 ## Get git bash completion
 ```sh
-curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc
+curl -L http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc
 ```
 
 ## What changed since two weeks?

--- a/tips.json
+++ b/tips.json
@@ -104,7 +104,7 @@
 		"tip": "git add -p"
 	}, {
 		"title": "Get git bash completion",
-		"tip": "curl http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc"
+		"tip": "curl -L http://git.io/vfhol > ~/.git-completion.bash && echo '[ -f ~/.git-completion.bash ] && . ~/.git-completion.bash' >> ~/.bashrc"
 	}, {
 		"title": "What changed since two weeks?",
 		"tip": "git log --no-merges --raw --since='2 weeks ago'",


### PR DESCRIPTION
This current command doesn't currently work because it downloads the html of the redirect page instead of the bash file. As per comments on #154, add -L flag to get the correct file. 