### PR TITLE
Add Prevent auto replacing LF with CRLF

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [Change a branch base](#change-a-branch-base)
 * [Use SSH instead of HTTPs for remotes](#use-ssh-instead-of-https-for-remotes)
 * [Update a submodule to the latest commit](#update-a-submodule-to-the-latest-commit)
+* [Prevent auto replacing LF with CRLF](#prevent-auto-replacing-lf-with-crlf)
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->
 <!-- @doxie.inject end toc -->
@@ -1222,6 +1223,11 @@ git pull origin <branch>
 cd <root-of-your-main-project>
 git add <path-to-submodule>
 git commit -m "submodule updated"
+```
+
+## Prevent auto replacing LF with CRLF
+```sh
+git config --global core.autocrlf false
 ```
 
 <!-- Don’t remove or change the comment below – that can break automatic updates. More info at <http://npm.im/doxie.inject>. -->

--- a/tips.json
+++ b/tips.json
@@ -515,5 +515,8 @@
 	}, {
 		"title": "Update a submodule to the latest commit",
 		"tip": "cd <path-to-submodule>\ngit pull origin <branch>\ncd <root-of-your-main-project>\ngit add <path-to-submodule>\ngit commit -m \"submodule updated\""
-        }
+	}, {
+		"title": "Prevent auto replacing LF with CRLF",
+		"tip": "git config --global core.autocrlf false"
+	}
 ]


### PR DESCRIPTION
Hello. I Add prevent auto replacing LF with CRLF
which often occurs using other text editors together with vim.

This PR can remove below warnings.
$ warning: LF will be replaced by CRLF in "filename"

Also i follow easy step of contributing.md.
Check and merge plz. thank u :)