### PR TITLE
replacing `git stash save` by `git stash push`

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ git stash
 
 __Alternatives:__
 ```sh
-git stash push
+git stash save
 ```
 
 ## Saving current state of unstaged changes to tracked files
@@ -458,7 +458,7 @@ git stash --keep-index
 
 
 ```sh
-git stash push --keep-index
+git stash save --keep-index
 ```
 
 ## Saving current state including untracked files
@@ -469,23 +469,17 @@ git stash -u
 
 __Alternatives:__
 ```sh
-git stash push -u
+git stash save -u
 ```
 
 
 ```sh
-git stash push --include-untracked
+git stash save --include-untracked
 ```
 
 ## Saving current state with message
 ```sh
-git stash push -m  <message>
-```
-
-
-__Alternatives:__
-```sh
-git stash push --message <message>
+git stash save <message>
 ```
 
 ## Saving current state of all files (ignored, untracked, and tracked)
@@ -501,7 +495,7 @@ git stash --all
 
 
 ```sh
-git stash push --all
+git stash save --all
 ```
 
 ## Show list of all saved stashes

--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ git stash
 
 __Alternatives:__
 ```sh
-git stash save
+git stash push
 ```
 
 ## Saving current state of unstaged changes to tracked files
@@ -458,7 +458,7 @@ git stash --keep-index
 
 
 ```sh
-git stash save --keep-index
+git stash push --keep-index
 ```
 
 ## Saving current state including untracked files
@@ -469,17 +469,23 @@ git stash -u
 
 __Alternatives:__
 ```sh
-git stash save -u
+git stash push -u
 ```
 
 
 ```sh
-git stash save --include-untracked
+git stash push --include-untracked
 ```
 
 ## Saving current state with message
 ```sh
-git stash save <message>
+git stash push -m  <message>
+```
+
+
+__Alternatives:__
+```sh
+git stash push --message <message>
 ```
 
 ## Saving current state of all files (ignored, untracked, and tracked)
@@ -495,7 +501,7 @@ git stash --all
 
 
 ```sh
-git stash save --all
+git stash push --all
 ```
 
 ## Show list of all saved stashes

--- a/tips.json
+++ b/tips.json
@@ -131,22 +131,23 @@
 	}, {
 		"title": "Saving current state of tracked files without commiting",
 		"tip": "git stash",
-		"alternatives": ["git stash save"]
+		"alternatives": ["git stash push"]
 	}, {
 		"title": "Saving current state of unstaged changes to tracked files",
 		"tip": "git stash -k",
-		"alternatives": ["git stash --keep-index", "git stash save --keep-index"]
+		"alternatives": ["git stash --keep-index", "git stash push --keep-index"]
 	}, {
 		"title": "Saving current state including untracked files",
 		"tip": "git stash -u",
-		"alternatives": ["git stash save -u", "git stash save --include-untracked"]
+		"alternatives": ["git stash push -u", "git stash push --include-untracked"]
 	}, {
 		"title": "Saving current state with message",
-		"tip": "git stash save <message>"
+		"tip": "git stash push -m <message>",
+		"alternatives": ["git stash push --message <message>"]
 	}, {
 		"title": "Saving current state of all files (ignored, untracked, and tracked)",
 		"tip": "git stash -a",
-		"alternatives": ["git stash --all", "git stash save --all"]
+		"alternatives": ["git stash --all", "git stash push --all"]
 	}, {
 		"title": "Show list of all saved stashes",
 		"tip": "git stash list"


### PR DESCRIPTION
`git stash save` -> This option is deprecated in favour of git stash push.
[git docs](https://git-scm.com/docs/git-stash#Documentation/git-stash.txt-save-p--patch-k--no-keep-index-u--include-untracked-a--all-q--quietltmessagegt)