### PR TITLE
Fix typo extra caret in git command Restore delete file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,7 +781,7 @@ git clean -X -f
 
 ## Restore deleted file.
 ```sh
-git checkout <deleting_commit>^ -- <file_path>
+git checkout <deleting_commit> -- <file_path>
 ```
 
 ## Restore file to a specific commit-hash

--- a/tips.json
+++ b/tips.json
@@ -278,7 +278,7 @@
 		"tip": "git clean -X -f"
 	}, {
 		"title": "Restore deleted file.",
-		"tip": "git checkout <deleting_commit>^ -- <file_path>"
+		"tip": "git checkout <deleting_commit> -- <file_path>"
 	}, {
 		"title": "Restore file to a specific commit-hash",
 		"tip": "git checkout <commit-ish> -- <file_path>"


### PR DESCRIPTION
Fix typo extra caret in git command Restore delete file.