### PR TITLE
Add tips to delete local branches that has been squash and merged in the remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,8 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [Rebases 'feature' to 'master' and merges it in to master ](#rebases-feature-to-master-and-merges-it-in-to-master)
 * [Archive the `master` branch](#archive-the-master-branch)
 * [Modify previous commit without modifying the commit message](#modify-previous-commit-without-modifying-the-commit-message)
-* [Prunes references to remote branches that have been deleted in the remote.](#prunes-references-to-remote-branches-that-have-been-deleted-in-the-remote)
+* [Prunes references to remove branches that have been deleted in the remote.](#prunes-references-to-remove-branches-that-have-been-deleted-in-the-remote)
+* [Delete local branches that has been squash and merged in the remote.](#delete-local-branches-that-has-been-squash-and-merged-in-the-remote)
 * [Retrieve the commit hash of the initial revision.](#retrieve-the-commit-hash-of-the-initial-revision)
 * [Visualize the version tree.](#visualize-the-version-tree)
 * [Visualize the tree including commits that are only referenced from reflogs](#visualize-the-tree-including-commits-that-are-only-referenced-from-reflogs)
@@ -442,7 +443,7 @@ git stash
 
 __Alternatives:__
 ```sh
-git stash save
+git stash push
 ```
 
 ## Saving current state of unstaged changes to tracked files
@@ -458,7 +459,7 @@ git stash --keep-index
 
 
 ```sh
-git stash save --keep-index
+git stash push --keep-index
 ```
 
 ## Saving current state including untracked files
@@ -469,17 +470,23 @@ git stash -u
 
 __Alternatives:__
 ```sh
-git stash save -u
+git stash push -u
 ```
 
 
 ```sh
-git stash save --include-untracked
+git stash push --include-untracked
 ```
 
 ## Saving current state with message
 ```sh
-git stash save <message>
+git stash push -m <message>
+```
+
+
+__Alternatives:__
+```sh
+git stash push --message <message>
 ```
 
 ## Saving current state of all files (ignored, untracked, and tracked)
@@ -495,7 +502,7 @@ git stash --all
 
 
 ```sh
-git stash save --all
+git stash push --all
 ```
 
 ## Show list of all saved stashes
@@ -645,7 +652,7 @@ git archive master --format=zip --output=master.zip
 git add --all && git commit --amend --no-edit
 ```
 
-## Prunes references to remote branches that have been deleted in the remote.
+## Prunes references to remove branches that have been deleted in the remote.
 ```sh
 git fetch -p
 ```
@@ -654,6 +661,11 @@ git fetch -p
 __Alternatives:__
 ```sh
 git remote prune origin
+```
+
+## Delete local branches that has been squash and merged in the remote.
+```sh
+git branch -vv | grep ': gone]' | awk '{print <!-- @doxie.inject start -->}' | xargs git branch -D
 ```
 
 ## Retrieve the commit hash of the initial revision.
@@ -1139,14 +1151,9 @@ git config [--global] --edit
 git blame -L <start>,<end>
 ```
 
-## List all Git variable.
+## Show a Git logical variable.
 ```sh
-git var -l
-```
-
-## Show a Git specific variable.
-```sh
-git var <variable>
+git var -l | <variable>
 ```
 
 ## Preformatted patch file.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,365 @@
 {
   "name": "tips",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "version": "1.0.0",
+      "license": "MIT",
+      "devDependencies": {
+        "doxie": "^0.2.2",
+        "doxie.append": "^0.1.0",
+        "doxie.inject": "^0.1.1",
+        "doxie.output": "^0.3.0",
+        "doxie.render": "^0.3.0",
+        "husky": "^0.8.1"
+      }
+    },
+    "node_modules/1-liners": {
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/1-liners/-/1-liners-0.3.6.tgz",
+      "integrity": "sha1-SDD+eLdTejaZ+IpdQqjtwa9mB/8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/101": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/101/-/101-1.6.3.tgz",
+      "integrity": "sha512-4dmQ45yY0Dx24Qxp+zAsNLlMF6tteCyfVzgbulvSyC7tCyd3V8sW76sS0tHq8NpcbXfWTKasfyfzU1Kd86oKzw==",
+      "dev": true,
+      "dependencies": {
+        "clone": "^1.0.2",
+        "deep-eql": "^0.1.3",
+        "keypather": "^1.10.2"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/array-find": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/array-find/-/array-find-1.0.0.tgz",
+      "integrity": "sha1-bI4obRHtdoMn+OYuzuhzU8o+eLg=",
+      "dev": true
+    },
+    "node_modules/base64-js": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-0.0.2.tgz",
+      "integrity": "sha1-Ak8Pcq+iW3X5wO5zzU9V7Bvtl4Q=",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/bops": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/bops/-/bops-0.0.6.tgz",
+      "integrity": "sha1-CC0dVfoB5g29wuvC26N/ZZVUzzo=",
+      "dev": true,
+      "dependencies": {
+        "base64-js": "0.0.2",
+        "to-utf8": "0.0.1"
+      }
+    },
+    "node_modules/chalk": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+      "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^2.2.1",
+        "escape-string-regexp": "^1.0.2",
+        "has-ansi": "^2.0.0",
+        "strip-ansi": "^3.0.0",
+        "supports-color": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8"
+      }
+    },
+    "node_modules/concat-stream": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.2.1.tgz",
+      "integrity": "sha1-81EAtsRjeL+6i2uA+fDQzN8T3GA=",
+      "dev": true,
+      "engines": [
+        "node >= 0.8.0"
+      ],
+      "dependencies": {
+        "bops": "0.0.6"
+      }
+    },
+    "node_modules/deep-eql": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-0.1.3.tgz",
+      "integrity": "sha1-71WKyrjeJSBs1xOQbXTlaTDrafI=",
+      "dev": true,
+      "dependencies": {
+        "type-detect": "0.1.1"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/defined": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
+      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
+      "dev": true
+    },
+    "node_modules/doxie": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/doxie/-/doxie-0.2.4.tgz",
+      "integrity": "sha1-KZltv1dg/OdNvLTXnGAjHYoXu4U=",
+      "dev": true,
+      "dependencies": {
+        "1-liners": "^0.3.2",
+        "chalk": "^1.0.0",
+        "doxie-core": "^0.3.1",
+        "stream-to-json": "^0.0.1",
+        "tiny-error": "^0.2.1"
+      },
+      "bin": {
+        "doxie": "bin/doxie.js"
+      }
+    },
+    "node_modules/doxie-core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/doxie-core/-/doxie-core-0.3.1.tgz",
+      "integrity": "sha1-PS+RQ+WF45Cpgwjcnk7zjxPPQss=",
+      "dev": true,
+      "dependencies": {
+        "1-liners": "^0.3.0",
+        "chalk": "^1.0.0",
+        "tiny-error": "^0.2.1"
+      }
+    },
+    "node_modules/doxie.append": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/doxie.append/-/doxie.append-0.1.0.tgz",
+      "integrity": "sha1-yHRoUEL18wlKTQwzNsPklMNpdOE=",
+      "dev": true,
+      "dependencies": {
+        "object-assign": "^3.0.0"
+      }
+    },
+    "node_modules/doxie.append/node_modules/object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/doxie.inject": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/doxie.inject/-/doxie.inject-0.1.1.tgz",
+      "integrity": "sha1-/QNYT4segOZEtcuUdpr+RH94oEc=",
+      "dev": true,
+      "dependencies": {
+        "1-liners": "^0.3.2",
+        "array-find": "^1.0.0",
+        "chalk": "^1.0.0",
+        "defined": "^1.0.0",
+        "object-assign": "^3.0.0",
+        "tiny-error": "^0.2.1"
+      }
+    },
+    "node_modules/doxie.inject/node_modules/object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/doxie.output": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/doxie.output/-/doxie.output-0.3.0.tgz",
+      "integrity": "sha1-4H4Stn2qX8KLPsZn0HAv1ziZitE=",
+      "dev": true,
+      "dependencies": {
+        "1-liners": "^0.3.0",
+        "object-assign": "^3.0.0"
+      }
+    },
+    "node_modules/doxie.output/node_modules/object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/doxie.render": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/doxie.render/-/doxie.render-0.3.2.tgz",
+      "integrity": "sha1-Mva37g88NSSokT08grn6uqoKGPA=",
+      "dev": true,
+      "dependencies": {
+        "1-liners": "^0.3.1",
+        "chalk": "^1.0.0",
+        "object-assign": "^3.0.0",
+        "tiny-error": "^0.2.1"
+      }
+    },
+    "node_modules/doxie.render/node_modules/object-assign": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-3.0.0.tgz",
+      "integrity": "sha1-m+3VygiXlJvKR+f/QIBi1Un1h/I=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/has-ansi": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/husky": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.8.1.tgz",
+      "integrity": "sha1-7MeXuMTGiToz9IcDvJeppeUNhg8=",
+      "dev": true,
+      "hasInstallScript": true
+    },
+    "node_modules/keypather": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/keypather/-/keypather-1.10.2.tgz",
+      "integrity": "sha1-4ESWMtSz5RbyHMAUznxWRP3c5hQ=",
+      "dev": true,
+      "dependencies": {
+        "101": "^1.0.0"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+      "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+      "dev": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/stream-to-json": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/stream-to-json/-/stream-to-json-0.0.1.tgz",
+      "integrity": "sha1-8DDyt47TjkkpPbiFZTarzCZ3FHM=",
+      "dev": true,
+      "dependencies": {
+        "concat-stream": "~1.2.0",
+        "once": "~1.3.0"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/tiny-error": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tiny-error/-/tiny-error-0.2.3.tgz",
+      "integrity": "sha1-KHas/leFGwcUMTwVNd/HBgp8Cbs=",
+      "dev": true,
+      "dependencies": {
+        "101": "^1.0.0",
+        "object-assign": "^4.0.1"
+      }
+    },
+    "node_modules/to-utf8": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/to-utf8/-/to-utf8-0.0.1.tgz",
+      "integrity": "sha1-0Xrqcv8vujm55DYBvns/9y4ImFI=",
+      "dev": true
+    },
+    "node_modules/type-detect": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-0.1.1.tgz",
+      "integrity": "sha1-C6XsKohWQORw6k6FBZcZANrFiCI=",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  },
   "dependencies": {
     "101": {
       "version": "1.6.3",

--- a/tips.json
+++ b/tips.json
@@ -216,9 +216,12 @@
 		"title": "Modify previous commit without modifying the commit message",
 		"tip": "git add --all && git commit --amend --no-edit"
 	}, {
-		"title": "Prunes references to remote branches that have been deleted in the remote.",
+		"title": "Prunes references to remove branches that have been deleted in the remote.",
 		"tip": "git fetch -p",
 		"alternatives": ["git remote prune origin"]
+	}, {
+		"title": "Delete local branches that has been squash and merged in the remote.",
+		"tip": "git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D"
 	}, {
 		"title": "Retrieve the commit hash of the initial revision.",
 		"tip": " git rev-list --reverse HEAD | head -1",


### PR DESCRIPTION
Very usefull when commit policy of the organisation is to `squash en merge` or `rebase and merge` the pull requests.

As a complement to `git fetch -p` :
```
git fetch -p && git branch -vv | grep ': gone]' | awk '{print $1}' | xargs git branch -D
```
source : [stackoverflow: Remove tracking branches no longer on remote](https://stackoverflow.com/questions/7726949/remove-tracking-branches-no-longer-on-remote/33548037#33548037)

Maybe should we also put the `git fetch -p && `  part in git-tips ?! (not sure..)