### PR TITLE
Add a tip to omit writing branch names when push

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,7 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [List all git aliases](#list-all-git-aliases)
 * [Show git status short](#show-git-status-short)
 * [Checkout a commit prior to a day ago](#checkout-a-commit-prior-to-a-day-ago)
+* [Push the current branch to the same name on the remote repository](#push-the-current-branch-to-the-same-name-on-the-remote-repository)
 * [Push a new local branch to remote repository and track](#push-a-new-local-branch-to-remote-repository-and-track)
 * [Change a branch base](#change-a-branch-base)
 * [Use SSH instead of HTTPs for remotes](#use-ssh-instead-of-https-for-remotes)
@@ -1211,6 +1212,11 @@ git status --short --branch
 ## Checkout a commit prior to a day ago
 ```sh
 git checkout master@{yesterday}
+```
+
+## Push the current branch to the same name on the remote repository
+```sh
+git push origin HEAD
 ```
 
 ## Push a new local branch to remote repository and track

--- a/tips.json
+++ b/tips.json
@@ -508,6 +508,9 @@
 		"title": "Checkout a commit prior to a day ago",
 		"tip": "git checkout master@{yesterday}"
 	}, {
+		"title": "Push the current branch to the same name on the remote repository",
+		"tip": "git push origin HEAD"
+  }, {
 		"title": "Push a new local branch to remote repository and track",
 		"tip": "git push -u origin <branch_name>"
 	}, {


### PR DESCRIPTION
Useful when you create a new local branch and push it to remote.