### PR TITLE
Update "Delete remote tag" to match delete remote branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,18 @@ git tag -d <tag-name>
 
 ## Delete remote tag
 ```sh
+git push origin --delete refs/tags/<tag-name>
+```
+
+
+__Alternatives:__
+```sh
 git push origin :refs/tags/<tag-name>
+```
+
+
+```sh
+git push origin --delete <tag-name>
 ```
 
 ## Undo local changes with the content in index(staging)

--- a/README.md
+++ b/README.md
@@ -331,18 +331,13 @@ git tag -d <tag-name>
 
 ## Delete remote tag
 ```sh
-git push origin --delete refs/tags/<tag-name>
+git push origin --delete <tag-name>
 ```
 
 
 __Alternatives:__
 ```sh
 git push origin :refs/tags/<tag-name>
-```
-
-
-```sh
-git push origin --delete <tag-name>
 ```
 
 ## Undo local changes with the content in index(staging)

--- a/tips.json
+++ b/tips.json
@@ -73,8 +73,8 @@
 		"tip": "git tag -d <tag-name>"
 	}, {
 		"title": "Delete remote tag",
-		"tip": "git push origin --delete refs/tags/<tag-name>",
-		"alternatives": ["git push origin :refs/tags/<tag-name>", "git push origin --delete <tag-name>"]
+		"tip": "git push origin --delete <tag-name>",
+		"alternatives": ["git push origin :refs/tags/<tag-name>"]
 	}, {
 		"title": "Undo local changes with the content in index(staging)",
 		"tip": "git checkout -- <file_name>"

--- a/tips.json
+++ b/tips.json
@@ -73,7 +73,8 @@
 		"tip": "git tag -d <tag-name>"
 	}, {
 		"title": "Delete remote tag",
-		"tip": "git push origin :refs/tags/<tag-name>"
+		"tip": "git push origin --delete refs/tags/<tag-name>",
+		"alternatives": ["git push origin :refs/tags/<tag-name>", "git push origin --delete <tag-name>"]
 	}, {
 		"title": "Undo local changes with the content in index(staging)",
 		"tip": "git checkout -- <file_name>"


### PR DESCRIPTION
The `--delete` flag can be used for deleting both remote branches and tags. This updates "Delete remote tag" to do that. It also adds a deletion syntax without the `refs/tags` so it's known that it's usually not necessary.