### PR TITLE
chore: Generate `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ P.S: All these commands are tested on `git version 2.7.4 (Apple Git-66)`.
 * [Create local tag](#create-local-tag)
 * [Delete local tag](#delete-local-tag)
 * [Delete remote tag](#delete-remote-tag)
-* [Undo local changes with the last content in head](#undo-local-changes-with-the-last-content-in-head)
+* [Undo local changes with the content in index(staging)](#undo-local-changes-with-the-content-in-indexstaging)
 * [Revert: Undo a commit by creating a new commit](#revert-undo-a-commit-by-creating-a-new-commit)
 * [Reset: Discard commits, advised for private branch](#reset-discard-commits-advised-for-private-branch)
 * [Reword the previous commit message](#reword-the-previous-commit-message)
@@ -998,6 +998,7 @@ __Alternatives:__
 ```sh
 git branch <branch-name> && git checkout <branch-name>
 ```
+
 
 ```sh
 git switch -c <branch-name>


### PR DESCRIPTION
There have been some commits that have updated `tips.json`, but not the `README.md`. This fixes that.